### PR TITLE
Totally awesome app. Suggestion to add authorization step after firebase authentication

### DIFF
--- a/authorized_users.csv
+++ b/authorized_users.csv
@@ -1,0 +1,2 @@
+﻿useremail
+authorized@email.com

--- a/global.R
+++ b/global.R
@@ -1,3 +1,6 @@
 library(shiny)
 library(shinyjs)
 library(DT)
+
+# read list of authorized users
+auth_users <- readr::read_csv("authorized_users.csv")

--- a/server.R
+++ b/server.R
@@ -5,10 +5,12 @@ function(input, output, session) {
   observeEvent(input$go_to_register, {
     shinyjs::show("register_panel", anim = TRUE, animType = "fade")
     shinyjs::hide("sign_in_panel")
+    shinyjs::hide("not_authorized")
   }, ignoreInit = TRUE)
 
   observeEvent(input$go_to_sign_in, {
     shinyjs::hide("register_panel")
+    shinyjs::hide("not_authorized")
     shinyjs::show("sign_in_panel", anim = TRUE, animType = "fade")
   }, ignoreInit = TRUE)
 
@@ -20,12 +22,25 @@ function(input, output, session) {
       shinyjs::show("sign_in_panel")
       shinyjs::hide("main")
       shinyjs::hide("verify_email_view")
+      shinyjs::hide("not_authorized")
     } else {
       shinyjs::hide("sign_in_panel")
       shinyjs::hide("register_panel")
+      shinyjs::hide("not_authorized")
 
       if (current_user$emailVerified == TRUE) {
-        shinyjs::show("main")
+        
+        # read the email of the authenticated user
+        res1 <- signed_in_user_df()
+        email_logged <- res1$value[res1$name == "email"]
+        
+        # check if the email of the authenticated user is in auth_users
+        if (email_logged %in% auth_users$useremail){
+          shinyjs::show("main")
+        } else {
+          shinyjs::show("not_authorized")
+        }
+        
       } else {
         shinyjs::show("verify_email_view")
       }

--- a/sof-auth/not-authorized.R
+++ b/sof-auth/not-authorized.R
@@ -1,0 +1,22 @@
+hidden(div(
+  id = "not_authorized",
+  fluidRow(
+    column(
+      12,
+      tags$button(
+        id = "submit_sign_out",
+        type = "button",
+        "Sign Out",
+        class = "btn-danger pull-right",
+        style = "color: white;"
+      )
+    ),
+    column(
+      12,
+      h1("You are not authorized to use this app."),
+      br(),
+      p("Please contact your administrator.")
+    )
+  )
+)
+)

--- a/ui.R
+++ b/ui.R
@@ -12,10 +12,10 @@ fluidPage(
 
   # load shinyjs on
   shinyjs::useShinyjs(),
-
+  source("sof-auth/not-authorized.R", local = TRUE)$value,
   source("sof-auth/sign-in.R", local = TRUE)$value,
   source("sof-auth/register.R", local = TRUE)$value,
   source("sof-auth/verify-email.R", local = TRUE)$value,
-
+  
   source("ui/main.R", local = TRUE)$value
 )


### PR DESCRIPTION
This is a really awesome app. 

It really solved me a lot of troubles I have been handling and messing with lately. 

This pull request is a suggestion to add an additional step on top of the authentication, i.e., authorization. This is very useful in cases you want to limit the access to your app. Currently, any authenticated user can access the app.

A csv file `authorized_users.csv` is added and contains a list of users which are authorized to access the app. If a firebase authenticated user is not on the authorized users file, he sees a screen which denies access.